### PR TITLE
Use uniform error type.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -193,6 +193,7 @@ dependencies = [
  "clap",
  "quick-xml",
  "serde",
+ "thiserror",
  "zhconv",
 ]
 
@@ -489,6 +490,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,4 @@ zhconv = { version = "0.3.3", features = ["opencc"] }
 serde = { version = "1.0", features = ["derive"] }
 quick-xml = { version = "0.37.4", features = ["serialize"] }
 clap = { version = "4.5.37", features = ["derive"] }
+thiserror = { version = "2.0.12"}

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,16 +16,16 @@ fn main() {
 
     match args.command {
         Commands::ZhConv { source_language, target_languages, linguist_ts_file } => {
-            let result = subcmd_zhconv(source_language, target_languages, linguist_ts_file);
-            if result.is_err() {
+            subcmd_zhconv(source_language, target_languages, linguist_ts_file).unwrap_or_else(|err| {
+                eprintln!("\x1B[31m{0}\x1B[0m", err);
                 std::process::exit(1);
-            }
+            });
         },
         Commands::ZhConvPlain { target_languages, content } => {
-            let result = subcmd_zhconv_plain(target_languages, content);
-            if result.is_err() {
+            subcmd_zhconv_plain(target_languages, content).unwrap_or_else(|err| {
+                eprintln!("\x1B[31m{0}\x1B[0m", err);
                 std::process::exit(1);
-            }
+            });
         },
     }
 }

--- a/src/subcmd_zhconv.rs
+++ b/src/subcmd_zhconv.rs
@@ -2,56 +2,73 @@
 //
 // SPDX-License-Identifier: MIT
 
-use std::{fs, path::PathBuf};
-use quick_xml::Writer;
+use thiserror::Error as TeError;
+use std::path::PathBuf;
 use zhconv::zhconv;
 
 use crate::linguist_file::*;
 
-pub fn subcmd_zhconv(source_language: String, target_languages: Vec<String>, linguist_ts_file: PathBuf) -> Result<(), Box<dyn std::error::Error>> {
+#[derive(TeError, Debug)]
+pub enum CmdError {
+    #[error("Provided file {0:?} does not exist")]
+    FileNotFound(PathBuf),
+    #[error("Failed to get file name")]
+    NoFileName,
+    #[error("Failed to get directory name")]
+    NoDirName,
+    #[error("Input file {0:?} doesn't have the source language {1:?} in its file name.")]
+    MismatchedLanguage(PathBuf, String),
+    #[error("Fail to load source file {0:?} because: {1}")]
+    LoadSourceFile(PathBuf, #[source] TsLoadError),
+    #[error("Fail to load target file {0:?} because: {1}")]
+    LoadTargetFile(PathBuf, #[source] TsLoadError),
+    #[error("Target file {0:?} has different number of contexts")]
+    DifferentContexts(String),
+    #[error("Target file {0:?} has different number of messages")]
+    DifferentMessages(String),
+    #[error("Fail to save file {0:?} because: {1}")]
+    SaveFile(PathBuf, #[source] TsSaveError),
+    #[error("Fail to parse language code")]
+    ParseLanguageCode,
+}
+
+fn zhconv_wrapper(text: &String, target: &String) -> Result<String, CmdError> {
+    let target = correct_language_code(target);
+    let target = target.parse().or_else(|_err| { Err(CmdError::ParseLanguageCode) })?;
+    Ok(zhconv(text.as_str(), target))
+}
+
+pub fn subcmd_zhconv(source_language: String, target_languages: Vec<String>, linguist_ts_file: PathBuf) -> Result<(), CmdError> {
     if !linguist_ts_file.is_file() {
-        println!("Provided file {} does not exist", linguist_ts_file.display());
-        return Err("Provided file does not exist".into());
+        return Err(CmdError::FileNotFound(linguist_ts_file.clone()));
     }
-    let file_name = linguist_ts_file.file_name().ok_or("Failed to get file name").unwrap();
+    let file_name = linguist_ts_file.file_name().ok_or(CmdError::NoFileName)?;
     if !file_name.to_string_lossy().contains(&source_language) {
-        println!("Input file {linguist_ts_file:?} doesn't have the source language {source_language:?} in its file name.");
-        return Err("Input file doesn't match to the source language".into());
+        return Err(CmdError::MismatchedLanguage(linguist_ts_file.clone(), source_language.clone()));
     }
 
-    let source_content = match load_ts_file(&linguist_ts_file) {
-        Ok(source_content) => source_content,
-        Err(_e) => {
-            println!("Failed to load source file: {file_name:?}");
-            return Err("Failed to load source file".into());
-        }
-    };
+    let source_content = load_ts_file(&linguist_ts_file)
+        .or_else(|e| { Err(CmdError::LoadSourceFile(linguist_ts_file.clone(), e)) })?;
 
     let mut target_contents: Vec<(PathBuf, Ts)> = vec![];
     for target_language in target_languages {
         // replace the source language code with the target language code to get the target file name
         let target_file_name = file_name.to_string_lossy().replace(&source_language, &target_language);
-        let target_file_path = linguist_ts_file.parent().unwrap().join(&target_file_name);
-        let target_content = match load_ts_file_or_default(&target_file_path, &source_content, &target_language) {
-            Ok(target_content) => target_content,
-            Err(_e) => {
-                println!("Failed to load target file: {target_file_name:?}");
-                return Err("Failed to load target file".into());
-            }
-        };
+        let target_file_path = linguist_ts_file.parent().ok_or(CmdError::NoDirName)
+            .and_then(|p| { Ok(p.join(&target_file_name)) })?;
+        let target_content = load_ts_file_or_default(&target_file_path, &source_content, &target_language)
+            .or_else(|e| { Err(CmdError::LoadTargetFile(target_file_path.clone(), e)) })?;
         target_contents.push((target_file_path, target_content));
     }
 
     for (target_path, target_content) in &mut target_contents {
         if target_content.contexts.len() != source_content.contexts.len() {
-            println!("Target file {} has different number of contexts", target_content.language);
-            return Err("Target file has different number of contexts".into());
+            return Err(CmdError::DifferentContexts(target_content.language.clone()));
         }
         for (index, context) in target_content.contexts.iter_mut().enumerate() {
             let source_context = &source_content.contexts[index];
             if context.messages.len() != source_context.messages.len() {
-                println!("Target file {} has different number of messages", target_content.language);
-                return Err("Target file has different number of messages".into());
+                return Err(CmdError::DifferentMessages(target_content.language.clone()));
             }
             // for loop with index so we could access the source context and message at the same index
             for (index, message) in context.messages.iter_mut().enumerate() {
@@ -63,24 +80,23 @@ pub fn subcmd_zhconv(source_language: String, target_languages: Vec<String>, lin
                 if matches!(source_message.translation.type_attr, Some(ref s) if s == "unfinished") {
                     continue;
                 }
-                if source_message.translation.value.is_some() {
-                    message.translation.value = Some(zhconv(source_message.translation.value.as_ref().unwrap(), correct_language_code(&target_content.language).parse().unwrap()));
+                if let Some(value) = &source_message.translation.value {
+                    message.translation.value = Some(zhconv_wrapper(&value, &target_content.language)?);
                     message.translation.type_attr = None;
                 }
             }
         }
 
-        let target_file = fs::File::create(target_path)?;
-        let mut writer = Writer::new_with_indent(&target_file, b' ', 4);
-        writer.write_linguist_ts_file(&target_content).unwrap();
+        save_ts_file(&target_path, &target_content)
+            .or_else(|err| { Err(CmdError::SaveFile(target_path.clone(), err)) })?;
     }
 
     Ok(())
 }
 
-pub fn subcmd_zhconv_plain(target_languages: Vec<String>, content: String) -> Result<(), Box<dyn std::error::Error>> {
+pub fn subcmd_zhconv_plain(target_languages: Vec<String>, content: String) -> Result<(), CmdError> {
     for target_language in target_languages {
-        let converted = zhconv(content.as_str(), correct_language_code(&target_language).parse().unwrap());
+        let converted = zhconv_wrapper(&content, &target_language)?;
         println!("{}", converted);
     }
 


### PR DESCRIPTION
- add thiserror as dependency.
- use thiserror to create some error types and use them as the error type in Result instead of Box<dyn Error>.
- remove scattered println. use intensive eprintln in main.rs instead.
- move the logic of saving ts file into linguist_file module.
- make a wrapper for zhconv in private function for convenient call.
- add hardcode color output (Red) in main.rs for error message.