### PR TITLE
chore(CI): add GitHub Action build and test CI

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,0 +1,30 @@
+name: Rust
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+
+    runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        BUILD_TARGET: [release]
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Build
+      run: cargo build --profile ${{ matrix.BUILD_TARGET }} --verbose
+    - name: Run tests
+      run: cargo test --profile ${{ matrix.BUILD_TARGET }} --verbose
+    - name: Upload release artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: deepin-translation-utils
+        path: target/${{ matrix.BUILD_TARGET }}/deepin-translation-utils


### PR DESCRIPTION
Log:

## Summary by Sourcery

Add GitHub Actions workflow for building and testing the Rust project

Build:
- Configure workflow to build the project in release profile

CI:
- Create a GitHub Actions workflow to automatically build and test the project on push and pull requests to the master branch

Tests:
- Add automated test execution in the CI pipeline