### PR TITLE
refactor: cleanup zhconv and linguist file.

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -108,7 +108,7 @@ pub enum Commands {
 #[error("{0}")]
 pub enum CliError {
     ZhConv(#[from] crate::subcmd::zhconv::CmdError),
-    Statistics(#[from] crate::subcmd::statistics::CmdStatsError),
+    Statistics(#[from] crate::subcmd::statistics::CmdError),
     Yaml2TxConfig(#[from] crate::subcmd::yaml2txconfig::CmdY2TCError),
     TxConfig2Yaml(#[from] crate::subcmd::txconfig2yaml::CmdTC2YError),
 }
@@ -119,10 +119,10 @@ pub fn execute() -> Result<(), CliError> {
     use crate::subcmd;
     match args.command {
         Commands::ZhConv { source_language, target_languages, linguist_ts_file } => {
-            subcmd::subcmd_zhconv(source_language, target_languages, linguist_ts_file)?;
+            subcmd::subcmd_zhconv(&source_language, &target_languages, &linguist_ts_file)?;
         },
         Commands::ZhConvPlain { target_languages, content } => {
-            subcmd::subcmd_zhconv_plain(target_languages, content)?;
+            subcmd::subcmd_zhconv_plain(&target_languages, &content)?;
         },
         Commands::Statistics { project_root, format, sort_by} => {
             subcmd::subcmd_statistics(&project_root, format, sort_by)?;

--- a/src/i18n_file.rs
+++ b/src/i18n_file.rs
@@ -2,7 +2,6 @@
 //
 // SPDX-License-Identifier: MIT
 
-pub mod cli;
-pub mod i18n_file;
-pub mod transifex;
-pub mod subcmd;
+pub mod common;
+pub mod linguist;
+pub mod gettext;

--- a/src/i18n_file/common.rs
+++ b/src/i18n_file/common.rs
@@ -1,0 +1,72 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: MIT
+
+use serde::Serialize;
+use std::path::Path;
+use thiserror::Error as TeError;
+
+pub enum I18nFileKind {
+    /// Qt Linguist translation file format (.ts)
+    Linguist,
+    /// GNU Gettext translation file format (.po)
+    Gettext,
+}
+
+#[derive(TeError, Debug)]
+#[error("Unknow translation file extension {ext:?}")]
+pub struct UnknownI18nFileExtError {
+    ext: String
+}
+
+impl I18nFileKind {
+    /// Try detecting translation file kind from given file path.
+    /// 
+    /// If file extension is `ts`, return Qt Linguist.
+    /// If file extension is `po` or `pot`, return GNU Gettext.
+    /// Otherwise return error.
+    pub fn from_ext_hint(path_hint: &Path) -> Result<Self, UnknownI18nFileExtError> {
+        // Get file extension and convert ot lowercase.
+        let ext = path_hint
+            .extension()
+            .map(|e| e.to_ascii_lowercase());
+        let ext = match ext {
+            Some(ref e) => e.to_str(),
+            None => None,
+        };
+        // Match extension.
+        match ext {
+            Some("ts") => Ok(Self::Linguist),
+            Some("po") | Some("pot") => Ok(Self::Gettext),
+            Some(s) => Err(UnknownI18nFileExtError { ext: s.to_string() }),
+            None => Err(UnknownI18nFileExtError { ext: String::new() }),
+        }
+    }
+}
+
+#[derive(Debug, Default, Serialize, PartialEq)]
+pub struct MessageStats {
+    pub finished: u64,
+    pub unfinished: u64,
+    pub vanished: u64,
+    pub obsolete: u64,
+}
+
+impl MessageStats {
+    pub fn completeness_percentage(&self) -> f64 {
+        let total = self.finished + self.unfinished;
+        if total == 0 {
+            return 0.0;
+        }
+        (self.finished as f64 / total as f64) * 100.0
+    }
+}
+
+impl std::ops::AddAssign<&Self> for MessageStats {
+    fn add_assign(&mut self, rhs: &Self) {
+        self.finished += rhs.finished;
+        self.unfinished += rhs.unfinished;
+        self.vanished += rhs.vanished;
+        self.obsolete += rhs.obsolete;
+    }
+}

--- a/src/i18n_file/gettext.rs
+++ b/src/i18n_file/gettext.rs
@@ -1,0 +1,146 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: MIT
+
+use std::path::Path;
+use polib::message::{MessageMutView, MessageView};
+use polib::po_file::{self, POParseError};
+use thiserror::Error as TeError;
+use super::common::MessageStats;
+
+// ===== PO Basic =====
+
+#[derive(Debug, Clone)]
+pub struct Po {
+    pub inner: polib::catalog::Catalog,
+}
+
+impl Po {
+    pub fn clear_finished_messages(&mut self) {
+        let catalog = &mut self.inner;
+        for mut message in catalog.messages_mut() {
+            if message.is_translated() && !message.is_plural() {
+                // This can not be failed because we have checked whether it is plural.
+                // Unwrap directly.
+                message.set_msgstr(String::new()).unwrap();
+            }
+        }
+    }
+}
+
+impl Po {
+    pub fn get_language(&self) -> String {
+        self.inner.metadata.language.clone()
+    }
+
+    pub fn set_language(&mut self, language: &str) {
+        self.inner.metadata.language = language.to_string();
+    }
+
+    pub fn get_message_stats(&self) -> MessageStats {
+        let mut stats = MessageStats::default();
+        for message in self.inner.messages() {
+            if message.is_translated() {
+                stats.finished += 1;
+            } else {
+                stats.unfinished += 1;
+            }
+        }
+        return stats;
+    }
+}
+
+// ===== PO Load & Save =====
+
+#[derive(TeError, Debug)]
+pub enum PoLoadError {
+    #[error("Fail to parse PO file: {0}")]
+    ParsePo(#[from] POParseError),
+}
+
+#[derive(TeError, Debug)]
+pub enum PoSaveError {
+    #[error("Fail to save PO file: {0}")]
+    WritePo(#[from] std::io::Error),
+}
+
+impl Po {
+    pub fn load_from_file(po_file: &Path) -> Result<Po, PoLoadError> {
+        Ok(Po {
+            inner: po_file::parse(po_file)?,
+        })
+    }
+
+    #[cfg(test)]
+    pub fn load_from_str(content: &str) -> Result<Po, PoLoadError> {
+        let reader = std::io::Cursor::new(content.as_bytes());
+        Ok(Po {
+            inner: po_file::parse_from_reader(reader)?
+        })
+    }
+
+    pub fn load_from_file_or_default(po_file: &Path, fallback: &Po, fallback_language_code: &str) -> Result<Po, PoLoadError> {
+        if !po_file.exists() {
+            let mut po = fallback.clone();
+            po.set_language(fallback_language_code);
+            po.clear_finished_messages();
+            return Ok(po);
+        } else {
+            return Self::load_from_file(po_file);
+        }
+    }
+
+    pub fn save_into_file(&self, po_file: &Path) -> Result<(), PoSaveError> {
+        po_file::write_to_file(&self.inner, po_file)?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    use super::super::common::MessageStats;
+    use super::*;
+
+    pub const TEST_ZH_CN_PO_CONTENT: &str = r#"msgid ""
+msgstr ""
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"Language: zh_CN\n"
+"X-Source-Language: C\n"
+"X-Qt-Contexts: true\n"
+
+#: ../../widget/mainwindow.ui:17
+msgctxt "ts::SampleContext|"
+msgid "A friend in need is a friend indeed"
+msgstr "海内存知己"
+
+#: ../../widget/mainwindow.ui:43 ../../widget/mainwindow.cpp:65
+msgctxt "ts::SampleContext|"
+msgid "Software engineer using mouse to manipulate the cursor on the screen"
+msgstr "软件开发工程师在使用鼠标操作屏幕上的光标"
+
+#, fuzzy
+#~ msgctxt "ts::SampleContext|"
+#~ msgid "TV band"
+#~ msgstr "电视频段"
+
+msgctxt "ts::SampleContext|"
+msgid "England"
+msgstr ""
+"#;
+
+    #[test]
+    fn tst_parse_po_content() {
+        let po = Po::load_from_str(TEST_ZH_CN_PO_CONTENT).unwrap();
+        assert_eq!(po.get_language(), "zh_CN");
+        assert_eq!(po.get_message_stats(), MessageStats {
+            finished: 2,
+            unfinished: 2,
+            vanished: 0,
+            obsolete: 0,
+        });
+        assert_eq!(po.get_message_stats().completeness_percentage(), 2.0 / 4.0 * 100.0);
+    }
+}

--- a/src/subcmd/zhconv.rs
+++ b/src/subcmd/zhconv.rs
@@ -3,11 +3,9 @@
 // SPDX-License-Identifier: MIT
 
 use thiserror::Error as TeError;
-use std::path::PathBuf;
-use polib::{message::{MessageMutView, MessageView}, po_file::{self, POParseError}};
+use std::path::{Path, PathBuf};
 use zhconv::zhconv;
-
-use crate::linguist_file::*;
+use crate::i18n_file::{self, linguist::Ts, gettext::Po};
 
 #[derive(TeError, Debug)]
 pub enum CmdError {
@@ -19,198 +17,48 @@ pub enum CmdError {
     NoDirName,
     #[error("Input file {0:?} doesn't have the source language {1:?} in its file name.")]
     MismatchedLanguage(PathBuf, String),
-    #[error("Fail to load source file {0:?} because: {1}")]
-    LoadSourceFile(PathBuf, #[source] TsLoadError),
-    #[error("Fail to load source file {0:?} because: {1}")]
-    LoadPOSourceFile(PathBuf, #[source] POParseError),
-    #[error("Fail to load target file {0:?} because: {1}")]
-    LoadTargetFile(PathBuf, #[source] TsLoadError),
     #[error("Target file {0:?} has different number of contexts")]
     DifferentContexts(String),
     #[error("Target file for language {0:?} has different number of messages (Source {1:?} != Target {2:?})")]
     DifferentMessages(String, usize, usize),
-    #[error("Fail to save file {0:?} because: {1}")]
-    SaveFile(PathBuf, #[source] TsSaveError),
-    #[error("Fail to save file {0:?} because: {1}")]
-    SavePOFile(PathBuf, #[source] std::io::Error),
     #[error("Fail to parse language code")]
     ParseLanguageCode,
     #[error("Missing language code in Linguist TS file")]
     MissingLanguageCode,
+    #[error("Can not guess translation file kind from path {0:?} because: {1}")]
+    GuessI18nFileType(PathBuf, #[source] i18n_file::common::UnknownI18nFileExtError),
+    #[error("The translation file type of target file and reference file is mismatched.")]
+    MismatchedI18nFileType,
+    #[error("Fail to load source file {0:?} because: {1}")]
+    LoadTsSourceFile(PathBuf, #[source] i18n_file::linguist::TsLoadError),
+    #[error("Fail to load source file {0:?} because: {1}")]
+    LoadPoSourceFile(PathBuf, #[source] i18n_file::gettext::PoLoadError),
+    #[error("Fail to load target file {0:?} because: {1}")]
+    LoadTsTargetFile(PathBuf, #[source] i18n_file::linguist::TsLoadError),
+    #[error("Fail to load target file {0:?} because: {1}")]
+    LoadPoTargetFile(PathBuf, #[source] i18n_file::gettext::PoLoadError),
+    #[error("Fail to save file {0:?} because: {1}")]
+    SaveTsFile(PathBuf, #[source] i18n_file::linguist::TsSaveError),
+    #[error("Fail to save file {0:?} because: {1}")]
+    SavePoFile(PathBuf, #[source] i18n_file::gettext::PoSaveError),
 }
 
-fn zhconv_wrapper(text: &String, target: &String) -> Result<String, CmdError> {
+// ===== Utils Functions =====
+
+fn correct_language_code(language_code: &str) -> String {
+    return language_code.replace("_", "-");
+}
+
+fn zhconv_wrapper(text: &str, target: &str) -> Result<String, CmdError> {
     let target = correct_language_code(target);
-    let target = target.parse().or_else(|_err| { Err(CmdError::ParseLanguageCode) })?;
-    Ok(zhconv(text.as_str(), target))
-}
-
-trait ZhConvertible {
-    type T;
-
-    fn load_file(file_path: &PathBuf) -> Result<Self::T, CmdError>;
-    fn load_or_create_target_file(&self, file_path: &PathBuf, fallback_language_code: &String) -> Result<Self::T, CmdError>;
-    fn language(&self) -> Option<String>;
-    fn set_language(&mut self, language_code: &String);
-    fn translate_content_based_on(&mut self, reference_content: &Self::T) -> Result<(), CmdError>;
-    fn save_file(&self, file_path: &PathBuf) -> Result<(), CmdError>;
-}
-
-enum ZhConvertibleType {
-    Ts(Ts),
-    Po(polib::catalog::Catalog),
-}
-
-impl ZhConvertible for ZhConvertibleType {
-    type T = Self;
-    
-    fn load_file(file_path: &PathBuf) -> Result<Self::T, CmdError> {
-        if !file_path.exists() {
-            return Err(CmdError::FileNotFound(file_path.clone()));
-        }
-        if file_path.extension().and_then(|e| e.to_str()) == Some("ts") {
-            Ts::load_file(file_path).map(Self::Ts)
-        } else {
-            polib::catalog::Catalog::load_file(file_path).map(Self::Po)
-        }
-    }
-    
-    fn load_or_create_target_file(&self, file_path: &PathBuf, fallback_language_code: &String) -> Result<Self::T, CmdError> {
-        match self {
-            Self::Ts(ts) => ts.load_or_create_target_file(file_path, fallback_language_code).map(Self::Ts),
-            Self::Po(po) => po.load_or_create_target_file(file_path, fallback_language_code).map(Self::Po),
-        }
-    }
-
-    fn language(&self) -> Option<String> {
-        match self {
-            Self::Ts(ts) => ts.language(),
-            Self::Po(po) => po.language(),
-        }
-    }
-    
-    fn set_language(&mut self, language_code: &String) {
-        match self {
-            Self::Ts(ts) => ts.set_language(language_code),
-            Self::Po(po) => po.set_language(language_code),
-        }
-    }
-    
-    fn translate_content_based_on(&mut self, reference_content: &Self) -> Result<(), CmdError> {
-        match self {
-            Self::Ts(ts) => {
-                if let Self::Ts(reference_ts) = reference_content {
-                    ts.translate_content_based_on(reference_ts)
-                } else {
-                    panic!("Unexpected reference content type")
-                }
-            }
-            Self::Po(po) => {
-                if let Self::Po(reference_po) = reference_content {
-                    po.translate_content_based_on(reference_po)
-                } else {
-                    panic!("Unexpected reference content type")
-                }
-            }
-        }
-    }
-    
-    fn save_file(&self, file_path: &PathBuf) -> Result<(), CmdError> {
-        match self {
-            Self::Ts(ts) => ts.save_file(file_path),
-            Self::Po(po) => po.save_file(file_path),
-        }
-    }
-}
-
-impl ZhConvertible for polib::catalog::Catalog {
-    type T = Self;
-    fn load_file(file_path: &PathBuf) -> Result<Self, CmdError> {
-        po_file::parse(file_path).map_err(|e| {CmdError::LoadPOSourceFile(file_path.clone(), e)})
-    }
-    
-    fn load_or_create_target_file(&self, file_path: &PathBuf, fallback_language_code: &String) -> Result<Self, CmdError> {
-        if !file_path.exists() {
-            let mut catalog = self.clone();
-            catalog.set_language(fallback_language_code);
-            for mut message in catalog.messages_mut() {
-                if message.is_translated() && !message.is_plural() {
-                    message.set_msgstr(String::new()).expect("Plural messages are not supported currently.")
-                }
-            }
-            return Ok(catalog);
-        } else {
-            return Self::load_file(file_path);
-        }
-    }
-
-    fn language(&self) -> Option<String> {
-        Some(self.metadata.language.clone())
-    }
-    
-    fn set_language(&mut self, language_code: &String) {
-        self.metadata.language = language_code.clone();
-    }
-    
-    fn translate_content_based_on(&mut self, reference_content: &Self::T) -> Result<(), CmdError> {
-        if self.messages().count() != reference_content.messages().count() {
-            return Err(CmdError::DifferentMessages(self.metadata.language.clone(), reference_content.messages().count(), self.messages().count()));
-        };
-        let language_code = self.metadata.language.clone();
-        for (index, mut message) in self.messages_mut().enumerate() {
-            let reference_message = reference_content.messages().nth(index).expect("Messages count mismatch");
-            if message.is_translated() {
-                continue;
-            };
-            if reference_message.is_translated() && !message.is_translated() && !message.is_plural() {
-                let msgstr = reference_message.msgstr().expect("Plural messages are not supported currently.").to_string();
-                let translated_msg = &zhconv_wrapper(&msgstr, &language_code)?;
-                message.set_msgstr(translated_msg.clone()).expect("Plural messages are not supported currently.");
-            };
-        };
-        Ok(())
-    }
-
-    fn save_file(&self, file_path: &PathBuf) -> Result<(), CmdError> {
-        po_file::write_to_file(self, file_path).map_err(|e| {CmdError::SavePOFile(file_path.clone(), e)})
-    }
-}
-
-impl ZhConvertible for Ts {
-    type T = Self;
-    fn load_file(file_path: &PathBuf) -> Result<Self, CmdError> {
-        load_ts_file(file_path).or_else(|e| {
-            Err(CmdError::LoadSourceFile(file_path.clone(), e))
-        })
-    }
-
-    fn load_or_create_target_file(&self, file_path: &PathBuf, fallback_language_code: &String) -> Result<Ts, CmdError> {
-        load_ts_file_or_default(file_path, &self, fallback_language_code).or_else(|e| {
-            Err(CmdError::LoadTargetFile(file_path.clone(), e))
-        })
-    }
-
-    fn language(&self) -> Option<String> {
-        self.language.clone()
-    }
-
-    fn set_language(&mut self, language_code: &String) {
-        self.set_language(language_code);
-    }
-
-    fn translate_content_based_on(&mut self, reference_content: &Self) -> Result<(), CmdError> {
-        translate_ts_content(&reference_content, self)
-    }
-
-    fn save_file(&self, file_path: &PathBuf) -> Result<(), CmdError> {
-        save_ts_file(file_path, &self).or_else(|e| {
-            Err(CmdError::SaveFile(file_path.clone(), e))
-        })
-    }
+    let target = target.parse().map_err(|_| CmdError::ParseLanguageCode)?;
+    Ok(zhconv(text, target))
 }
 
 fn translate_ts_content(source_content: &Ts, target_content: &mut Ts) -> Result<(), CmdError> {
-    let language_code = target_content.language.as_ref().ok_or(CmdError::MissingLanguageCode)?;
+    use i18n_file::linguist::TranslationType;
+
+    let language_code = target_content.get_language().ok_or(CmdError::MissingLanguageCode)?;
     if target_content.contexts.len() != source_content.contexts.len() {
         return Err(CmdError::DifferentContexts(language_code.clone()));
     }
@@ -237,26 +85,130 @@ fn translate_ts_content(source_content: &Ts, target_content: &mut Ts) -> Result<
     Ok(())
 }
 
-pub fn subcmd_zhconv(source_language: String, target_languages: Vec<String>, linguist_ts_file: PathBuf) -> Result<(), CmdError> {
+fn translate_po_content(source_content: &Po, target_content: &mut Po) -> Result<(), CmdError> {
+    use polib::message::{MessageMutView, MessageView};
+
+    let language_code = target_content.get_language();
+    let source_catalog = &source_content.inner;
+    let target_catalog = &mut target_content.inner;
+
+    let target_msg_count = target_catalog.count();
+    let source_msg_count = source_catalog.count();
+    if target_msg_count != source_msg_count {
+        return Err(CmdError::DifferentMessages(language_code, source_msg_count, target_msg_count));
+    };
+    for (mut message, reference_message) in target_catalog.messages_mut().zip(source_catalog.messages()) {
+        if message.is_translated() {
+            continue;
+        };
+        if reference_message.is_translated() && !message.is_translated() && !message.is_plural() {
+            // We have checked plural case, unwrap directly.
+            let msgstr = reference_message.msgstr().unwrap().to_string();
+            let translated_msg = zhconv_wrapper(&msgstr, &language_code)?;
+            message.set_msgstr(translated_msg).unwrap();
+        };
+    }
+    Ok(())
+}
+
+// ===== Uniform Translation File =====
+
+enum ZhConvFile {
+    Linguist(Ts),
+    Gettext(Po),
+}
+impl ZhConvFile {
+    fn load_file(file_path: &Path) -> Result<Self, CmdError> {
+        use i18n_file::common::I18nFileKind;
+        // Detect translation file kind from given file extension.
+        let i18n_file_kind = I18nFileKind::from_ext_hint(file_path)
+            .map_err(|e| CmdError::GuessI18nFileType(file_path.to_path_buf(), e))?;
+        // Dispatch loading request.
+        Ok(match i18n_file_kind {
+            I18nFileKind::Linguist => Self::Linguist(
+                Ts::load_from_file(file_path)
+                    .map_err(|e| CmdError::LoadTsSourceFile(file_path.to_path_buf(), e))?,
+            ),
+            I18nFileKind::Gettext => Self::Gettext(
+                Po::load_from_file(file_path)
+                    .map_err(|e| CmdError::LoadPoSourceFile(file_path.to_path_buf(), e))?,
+            ),
+        })
+    }
+
+    fn load_or_create_target_file(&self, file_path: &Path, fallback_language_code: &str) -> Result<Self, CmdError> {
+        Ok(match self {
+            ZhConvFile::Linguist(ts) => Self::Linguist(
+                Ts::load_from_file_or_default(file_path, ts, fallback_language_code)
+                    .map_err(|e| CmdError::LoadTsTargetFile(file_path.to_path_buf(), e))?,
+            ),
+            ZhConvFile::Gettext(po) => Self::Gettext(
+                Po::load_from_file_or_default(file_path, po, fallback_language_code)
+                    .map_err(|e| CmdError::LoadPoTargetFile(file_path.to_path_buf(), e))?,
+            ),
+        })
+    }
+
+    fn get_language(&self) -> Option<String> {
+        match self {
+            ZhConvFile::Linguist(ts) => ts.get_language(),
+            ZhConvFile::Gettext(po) => Some(po.get_language()),
+        }
+    }
+
+    fn set_language(&mut self, language_code: &str) {
+        match self {
+            ZhConvFile::Linguist(ts) => ts.set_language(language_code),
+            ZhConvFile::Gettext(po) => po.set_language(language_code),
+        }
+    }
+    
+    fn translate_content_based_on(&mut self, reference_content: &Self) -> Result<(), CmdError> {
+        match (self, reference_content) {
+            (ZhConvFile::Linguist(lhs), ZhConvFile::Linguist(rhs)) => {
+                Ok(translate_ts_content(rhs, lhs)?)
+            },
+            (ZhConvFile::Gettext(lhs), ZhConvFile::Gettext(rhs)) => {
+                Ok(translate_po_content(rhs, lhs)?)
+            },
+            _ => Err(CmdError::MismatchedI18nFileType)
+        }
+    }
+
+    fn save_file(&self, file_path: &Path) -> Result<(), CmdError> {
+        Ok(match self {
+            ZhConvFile::Linguist(ts) => ts
+                .save_into_file(file_path)
+                .map_err(|e| CmdError::SaveTsFile(file_path.to_path_buf(), e))?,
+            ZhConvFile::Gettext(po) => po
+                .save_into_file(file_path)
+                .map_err(|e| CmdError::SavePoFile(file_path.to_path_buf(), e))?,
+        })
+    }
+}
+
+// ===== Sub Command =====
+
+pub fn subcmd_zhconv(source_language: &str, target_languages: &[String], linguist_ts_file: &Path) -> Result<(), CmdError> {
     if !linguist_ts_file.is_file() {
-        return Err(CmdError::FileNotFound(linguist_ts_file.clone()));
+        return Err(CmdError::FileNotFound(linguist_ts_file.to_path_buf()));
     }
     let file_name = linguist_ts_file.file_name().ok_or(CmdError::NoFileName)?;
     if !file_name.to_string_lossy().contains(&source_language) {
-        return Err(CmdError::MismatchedLanguage(linguist_ts_file.clone(), source_language.clone()));
+        return Err(CmdError::MismatchedLanguage(linguist_ts_file.to_path_buf(), source_language.to_string()));
     }
 
-    let source_content = ZhConvertibleType::load_file(&linguist_ts_file)?;
+    let source_content = ZhConvFile::load_file(linguist_ts_file)?;
 
-    let mut target_contents: Vec<(PathBuf, ZhConvertibleType)> = vec![];
+    let mut target_contents: Vec<(PathBuf, ZhConvFile)> = vec![];
     for target_language in target_languages {
         // replace the source language code with the target language code to get the target file name
-        let target_file_name = file_name.to_string_lossy().replace(&source_language, &target_language);
+        let target_file_name = file_name.to_string_lossy().replace(source_language, &target_language);
         let target_file_path = linguist_ts_file.parent().ok_or(CmdError::NoDirName)
-            .and_then(|p| { Ok(p.join(&target_file_name)) })?;
+            .and_then(|p| { Ok(p.join(target_file_name)) })?;
         let mut target_content = source_content.load_or_create_target_file(&target_file_path, &target_language)?;
         // if the target file's language code is not match to target_language, set it to target_language
-        if !matches!(&target_content.language(), Some(lang) if lang == &target_language) {
+        if !matches!(&target_content.get_language(), Some(lang) if lang == target_language.as_str()) {
             eprintln!("Warning: Target file {target_file_path:?} has no or unmatched language code, will set it to {target_language}.");
             target_content.set_language(&target_language);
         }
@@ -271,7 +223,7 @@ pub fn subcmd_zhconv(source_language: String, target_languages: Vec<String>, lin
     Ok(())
 }
 
-pub fn subcmd_zhconv_plain(target_languages: Vec<String>, content: String) -> Result<(), CmdError> {
+pub fn subcmd_zhconv_plain(target_languages: &[String], content: &str) -> Result<(), CmdError> {
     for target_language in target_languages {
         let converted = zhconv_wrapper(&content, &target_language)?;
         println!("{}", converted);
@@ -283,21 +235,42 @@ pub fn subcmd_zhconv_plain(target_languages: Vec<String>, content: String) -> Re
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::linguist_file::tests::*;
 
     #[test]
     fn tst_translate_ts_content() {
-        let source_ts: Ts = quick_xml::de::from_str(TEST_ZH_CN_TS_CONTENT).unwrap();
+        use crate::i18n_file::linguist::Ts;
+        use crate::i18n_file::linguist::tests::TEST_ZH_CN_TS_CONTENT;
+
+        let source_ts: Ts = Ts::load_from_from_str(TEST_ZH_CN_TS_CONTENT).unwrap();
         let mut target_ts: Ts = source_ts.clone();
-        target_ts.language = Some("zh_TW".to_string());
+        target_ts.set_language("zh_TW");
         target_ts.clear_finished_messages();
         assert!(translate_ts_content(&source_ts, &mut target_ts).is_ok());
-        assert_eq!(target_ts.language, Some("zh_TW".to_string()));
+        assert_eq!(target_ts.get_language(), Some("zh_TW".to_string()));
         assert_eq!(target_ts.contexts.len(), 1);
         assert_eq!(target_ts.contexts[0].messages.len(), 5);
         assert_eq!(target_ts.contexts[0].messages[0].translation.value, Some(String::from("海內存知己")));
         assert_eq!(target_ts.contexts[0].messages[1].translation.value, Some(String::from("軟體開發工程師在使用滑鼠操作螢幕上的游標")));
         assert_eq!(target_ts.contexts[0].messages[2].translation.value, Some(String::from("电视频段"))); // marked as obsolete, should not be translated.
         assert_eq!(target_ts.contexts[0].messages[3].translation.value, None); // source is also untranslated
+    }
+
+    #[test]
+    fn tst_translate_po_content() {
+        use crate::i18n_file::gettext::Po;
+        use crate::i18n_file::gettext::tests::TEST_ZH_CN_PO_CONTENT;
+
+        let source_po = Po::load_from_str(TEST_ZH_CN_PO_CONTENT).unwrap();
+        let mut target_po = source_po.clone();
+        target_po.set_language("zh_TW");
+        target_po.clear_finished_messages();
+        assert!(translate_po_content(&source_po, &mut target_po).is_ok());
+        assert_eq!(target_po.get_language(), "zh_TW".to_string());
+        assert_eq!(target_po.inner.count(), 4);
+        let mut msgs = target_po.inner.messages();
+        assert_eq!(msgs.next().unwrap().msgstr().unwrap(), "海內存知己");
+        assert_eq!(msgs.next().unwrap().msgstr().unwrap(), "軟體開發工程師在使用滑鼠操作螢幕上的游標");
+        assert_eq!(msgs.next().unwrap().msgstr().unwrap(), ""); // marked as obsolete. but polib will not read it.
+        assert_eq!(msgs.next().unwrap().msgstr().unwrap(), ""); // source is also untranslated
     }
 }


### PR DESCRIPTION
- use `&str` and `&Path` instead of `&String` and `&PathBuf` in files changed this time.
- rename something to make they are more in line with Rust's expressive habits.
	* rename `CmdStatsError` to `CmdError` in `subcmd::statistics`. it can be shorten without any name conflict.
	* remove the `Error` tail of members in some error enum.
	* correct `LoadPO` and `LoadPo`. Rust doesn't suggest left style.
	* correct `FileLoad` to `LoadFile`. Rust suggest that the verb should be the first position.
- create a new module folder `trfile` for holding various translation file logic.
	* create a `linguist` module for holding Qt Linguist TS file logic.
	* create a `gettext` module for holding GNU Gettext PO file logic.
	* create a `common` module for holding these 2 file types shared components.
- move `linguist_file`
	* most content are moved into `trfile::linguist`.
	* rename `TsMessageStats` to `MessageStats` and move it to `trfile::common`
	* remove useless import, such as `std::u64`.
	* create new function `get_language` for `Ts` to have uniform interface.
	* move `correct_language_code` to `subcmd::zhconv` because only this module use it.
- move Gettext PO file logic.
	* extract logic involving load, load with fallback, save, from `subcmd::zhconv`.
	* extract logic involving generate statistics from `subcmd::statistics`.
	* and put them into `trfile::gettext` with a proper wrapper (not in raw gettext catalog).
- cleanup `subcmd::zhconv` module
	* remove fat `ZhConvertible`, use lighter `ZhConvFile` enum instead.
	* clean all `expect()`
	* move the logic about translating PO content into a function `translate_po_content` and optimize its performance.
- extract the function, that guess the translation file type from the file extension, from `subcmd::{zhconv, statistics}` and put into `trfile::common` with a new created enum `TrFileKind`.
- move load, load with fallback, save logic into Ts and Po inside.
- add testing stuff.
	* add a load from string feature for Ts and Po only in test mode for convenient test.
	* add 2 unittest for new organised PO file logic in `subcmd::zhconv` and `trfile::gettext` respectively like TS file unittest.
- improve performances.
	* optimize ts load function. use `std::io::Read` trait instead of reading the whole file before parsing it.
	* optimize `subcmd::zhconv::translate_po_content` by using `Iterator::zip()` and caching length to reduce useless iterator calling.
- modify other modules according to hereinabove said changes to make project can be built.

## Summary by Sourcery

Refactor and reorganize translation file handling modules, improving code structure and maintainability by introducing a new `trfile` module with separate components for different translation file types.

New Features:
- Create a new `trfile` module with separate submodules for different translation file types
- Introduce a uniform interface for handling translation files
- Add a new `TrFileKind` enum for detecting translation file types

Enhancements:
- Improve error handling and type safety
- Optimize file loading and parsing methods
- Simplify translation file processing logic
- Reduce code duplication across translation file handling

Chores:
- Clean up imports
- Remove unused code
- Improve type signatures
- Update function signatures to use more idiomatic Rust patterns