### PR TITLE
feat: add fuzzy field in statistics info.

### DIFF
--- a/src/i18n_file/common.rs
+++ b/src/i18n_file/common.rs
@@ -16,7 +16,7 @@ pub enum I18nFileKind {
 #[derive(TeError, Debug)]
 #[error("Unknow translation file extension {ext:?}")]
 pub struct UnknownI18nFileExtError {
-    ext: String
+    ext: String,
 }
 
 impl I18nFileKind {
@@ -27,9 +27,7 @@ impl I18nFileKind {
     /// Otherwise return error.
     pub fn from_ext_hint(path_hint: &Path) -> Result<Self, UnknownI18nFileExtError> {
         // Get file extension and convert ot lowercase.
-        let ext = path_hint
-            .extension()
-            .map(|e| e.to_ascii_lowercase());
+        let ext = path_hint.extension().map(|e| e.to_ascii_lowercase());
         let ext = match ext {
             Some(ref e) => e.to_str(),
             None => None,
@@ -44,21 +42,85 @@ impl I18nFileKind {
     }
 }
 
+/// Universal message statistics infomations shared by all supported i18n file types.
 #[derive(Debug, Default, Serialize, PartialEq)]
 pub struct MessageStats {
+    /// The source text has been translated.
+    /// 
+    /// For Qt Linguist TS file, all entries without type attribute should be grouped into this field.
+    /// For GNU Gettext PO file, all translated entries should be grouped into this field.
     pub finished: u64,
+    /// The source text has not been translated.
+    /// 
+    /// For Qt Linguist TS file, entries with "Unfinished" type should be grouped into this field.
+    /// For GNU Gettext PO file, any other entries (not translated and not fuzzy) should be grouped into this field.
     pub unfinished: u64,
+    /// The source text of this entry no longer exists.
+    /// 
+    /// It is basically same as "obsolete".
+    /// The only reason why split them is to keep they are different in Qt scope.
+    /// 
+    /// For Qt Linguist TS file, entries with "Vanished" type should be grouped into this field.
+    /// For GNU Gettext PO file, no entry should be grouped into this.
     pub vanished: u64,
+    /// The source text of this entry no longer exists.
+    /// 
+    /// It is basically same as "vanished".
+    /// The only reason why split them is to keep they are different in Qt scope.
+    /// 
+    /// For Qt Linguist TS file, entries with "Obsolete" type should be grouped into this field.
+    /// For GNU Gettext PO file, no entry should be grouped into this.
     pub obsolete: u64,
+    /// The source text of this entry is still existing,
+    /// but has slight difference with old one,
+    /// so the translated text may not correct.
+    /// 
+    /// This usually happen when use `msgmerge` in PO file
+    /// when updating old translation file with new translation template,
+    /// and there is a slight difference between old entry and new entry.
+    /// 
+    /// For Qt Linguist TS file, no entry should be grouped into this.
+    /// For GNU Gettext PO file, all "fuzzy" entries should be grouped into this.
+    pub fuzzy: u64,
 }
 
 impl MessageStats {
+    pub fn new() -> Self {
+        MessageStats {
+            finished: 0,
+            unfinished: 0,
+            vanished: 0,
+            obsolete: 0,
+            fuzzy: 0,
+        }
+    }
+
+    /// The "Completeness" value shown in statistics table.
     pub fn completeness_percentage(&self) -> f64 {
-        let total = self.finished + self.unfinished;
+        let finished = self.shown_translated();
+        let unfinished = self.shown_unfinished();
+        
+        let total = finished + unfinished;
         if total == 0 {
             return 0.0;
+        } else {
+            (finished as f64 / total as f64) * 100.0
         }
-        (self.finished as f64 / total as f64) * 100.0
+    }
+
+    /// The "Translated" value shown in statistics table.
+    pub fn shown_translated(&self) -> u64 {
+        self.finished
+    }
+
+    /// The "Unfinished" value shown in statistics table.
+    pub fn shown_unfinished(&self) -> u64 {
+        self.unfinished + self.fuzzy
+    }
+
+    /// The "obsolete" value shown in statistics table.
+    pub fn shown_obsolete(&self) -> u64 {
+        self.obsolete + self.vanished
     }
 }
 
@@ -68,5 +130,6 @@ impl std::ops::AddAssign<&Self> for MessageStats {
         self.unfinished += rhs.unfinished;
         self.vanished += rhs.vanished;
         self.obsolete += rhs.obsolete;
+        self.fuzzy += rhs.fuzzy;
     }
 }

--- a/src/i18n_file/gettext.rs
+++ b/src/i18n_file/gettext.rs
@@ -38,10 +38,12 @@ impl Po {
     }
 
     pub fn get_message_stats(&self) -> MessageStats {
-        let mut stats = MessageStats::default();
+        let mut stats = MessageStats::new();
         for message in self.inner.messages() {
             if message.is_translated() {
                 stats.finished += 1;
+            } else if message.is_fuzzy() {
+                stats.fuzzy += 1;
             } else {
                 stats.unfinished += 1;
             }
@@ -137,9 +139,10 @@ msgstr ""
         assert_eq!(po.get_language(), "zh_CN");
         assert_eq!(po.get_message_stats(), MessageStats {
             finished: 2,
-            unfinished: 2,
+            unfinished: 1,
             vanished: 0,
             obsolete: 0,
+            fuzzy: 1,
         });
         assert_eq!(po.get_message_stats().completeness_percentage(), 2.0 / 4.0 * 100.0);
     }

--- a/src/i18n_file/linguist.rs
+++ b/src/i18n_file/linguist.rs
@@ -55,34 +55,18 @@ impl Ts {
     }
 
     pub fn get_message_stats(&self) -> MessageStats {
-        let mut finished = 0;
-        let mut unfinished = 0;
-        let mut vanished = 0;
-        let mut obsolete = 0;
+        let mut rv = MessageStats::new();
         for context in &self.contexts {
             for message in &context.messages {
                 match message.translation.type_attr {
-                    Some(TranslationType::Unfinished) => {
-                        unfinished += 1;
-                    }
-                    Some(TranslationType::Vanished) => {
-                        vanished += 1;
-                    }
-                    Some(TranslationType::Obsolete) => {
-                        obsolete += 1;
-                    }
-                    None => {
-                        finished += 1;
-                    }
+                    Some(TranslationType::Unfinished) => rv.unfinished += 1,
+                    Some(TranslationType::Vanished) => rv.vanished += 1,
+                    Some(TranslationType::Obsolete) => rv.obsolete += 1,
+                    None => rv.finished += 1,
                 }
             }
         }
-        return MessageStats {
-            finished,
-            unfinished,
-            vanished,
-            obsolete,
-        }
+        rv
     }
 }
 
@@ -261,6 +245,7 @@ pub mod tests {
             unfinished: 1,
             vanished: 0,
             obsolete: 1,
+            fuzzy: 0,
         });
         assert_eq!(ts.get_message_stats().completeness_percentage(), 3.0 / 4.0 * 100.0);
     }

--- a/src/subcmd/statistics.rs
+++ b/src/subcmd/statistics.rs
@@ -83,11 +83,11 @@ impl ProjectResourceStats {
     }
 
     pub fn print_state_plain_table(&self, sort_by: StatsSortBy) {
-        println!("| No. | Lang   | Completeness | Resources | Translated | Vanished | Obsolete |");
-        println!("| --- | ------ | ------------ | --------- | ---------- | -------- | -------- |");
+        println!("| No. | Lang   | Completeness | Resources | Translated | Unfinished | Vanished |");
+        println!("| --- | ------ | ------------ | --------- | ---------- | ---------- | -------- |");
         let (source_resources, source_stats) = self.get_source_stats();
-        println!("|   0 | Source | {0:>11.2}% | {1:9} | {2:10} | {3:8} | {4:8} |", 
-            100.0, source_resources, source_stats.finished + source_stats.unfinished, source_stats.vanished, source_stats.obsolete);
+        println!("|   0 | Source | {0:>11.2}% | {1:9} | {2:10} | {3:10} | {4:8} |", 
+            100.0, source_resources, source_stats.shown_translated() + source_stats.shown_unfinished(), 0, source_stats.shown_obsolete());
         let language_codes = match sort_by {
             StatsSortBy::LanguageCode => {
                 self.target_lang_codes.clone()
@@ -113,8 +113,8 @@ impl ProjectResourceStats {
         
         for (idx, lang) in language_codes.iter().enumerate() {
             let (target_resources, target_stats) = self.get_target_stats_by_language_code(&lang);
-            println!("| {0:3} | {1:>6} | {2:>11.2}% | {3:9} | {4:10} | {5:8} | {6:8} |", 
-                idx + 1, lang, target_stats.completeness_percentage(), target_resources, target_stats.finished, target_stats.vanished, target_stats.obsolete);
+            println!("| {0:3} | {1:>6} | {2:>11.2}% | {3:9} | {4:10} | {5:10} | {6:8} |", 
+                idx + 1, lang, target_stats.completeness_percentage(), target_resources, target_stats.shown_translated(), target_stats.shown_unfinished(), target_stats.shown_obsolete());
         }
     }
 


### PR DESCRIPTION
- add fuzzy field in MessageStats to handle PO file fuzzy entries properly.
- add Rust document for MessageStats and its fields to tell the meaning of these fields for developer.
- update MessageStats creation function for Ts and Po respectively.
- add 3 functions in MessageStats to compute values showen in `statistics.rs`.
	* finished field are shown as "translated"
	* obsolute and vanished fields are shown as "vanished".
	* unfinished and fuzzy fields are shown as "unfinished".
- update table columns and showcase in sub command statistics for hereinabove changes.

## Summary by Sourcery

Introduce support for fuzzy translation entries in statistics, update reporting logic and documentation, and adjust tests accordingly.

New Features:
- Add 'fuzzy' field to MessageStats to track fuzzy entries in PO files.

Enhancements:
- Update statistics computation and display to include fuzzy entries as unfinished and combine obsolete/vanished fields for reporting.
- Add developer-facing documentation for MessageStats and its fields.

Tests:
- Update and add tests to cover fuzzy entry handling in statistics.