### PR TITLE
refactor: rename some structs and fields to follow Rust naming conventions.

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -113,8 +113,8 @@ pub enum Commands {
 pub enum CliError {
     ZhConv(#[from] crate::subcmd::zhconv::CmdError),
     Statistics(#[from] crate::subcmd::statistics::CmdError),
-    Yaml2TxConfig(#[from] crate::subcmd::yaml2txconfig::CmdY2TCError),
-    TxConfig2Yaml(#[from] crate::subcmd::txconfig2yaml::CmdTC2YError),
+    Yaml2TxConfig(#[from] crate::subcmd::yaml2txconfig::CmdError),
+    TxConfig2Yaml(#[from] crate::subcmd::txconfig2yaml::CmdError),
 }
 
 pub fn execute() -> Result<(), CliError> {

--- a/src/subcmd/txconfig2yaml.rs
+++ b/src/subcmd/txconfig2yaml.rs
@@ -9,15 +9,15 @@ use thiserror::Error as TeError;
 use crate::transifex::{yaml_file::*, tx_config_file::*};
 
 #[derive(TeError, Debug)]
-pub enum CmdTC2YError {
+pub enum CmdError {
     #[error("Fail to load .tx/config file because: {0}")]
-    TxConfigLoadError(#[from] TxConfigLoadError),
+    LoadTxConfig(#[from] LoadTxConfigError),
     #[error("Fail to save transifex.yaml file because: {0}")]
-    TransifexYamlSaveError(#[from] serde_yml::Error),
+    SaveTransifexYaml(#[from] serde_yml::Error),
 }
 
-pub fn subcmd_txconfig2yaml(project_root: &PathBuf) -> Result<(), CmdTC2YError> {
-    let (tx_config_path, tx_config) = try_laod_tx_config_file(project_root)?;
+pub fn subcmd_txconfig2yaml(project_root: &PathBuf) -> Result<(), CmdError> {
+    let (tx_config_path, tx_config) = try_load_tx_config_file(project_root)?;
     let tx_yaml = tx_config.to_transifex_yaml();
     let tx_yaml_path = tx_config_path.parent().unwrap().join("transifex.yaml");
     if tx_yaml_path.exists() {

--- a/src/subcmd/yaml2txconfig.rs
+++ b/src/subcmd/yaml2txconfig.rs
@@ -15,9 +15,9 @@ use crate::transifex::{
 };
 
 #[derive(TeError, Debug)]
-pub enum CmdY2TCError {
+pub enum CmdError {
     #[error("Fail to load transifex.yaml file because: {0}")]
-    TxYamlLoadError(#[from] TxYamlLoadError),
+    LoadTxYaml(#[from] LoadTxYamlError),
 }
 
 fn get_github_repository_from_user_input(project_root: &PathBuf, github_repository_hint: Option<String>) -> String {
@@ -120,8 +120,8 @@ pub fn create_linked_resources_table(organization_slug: &str, project_slug: Opti
     lookup_table
 }
 
-pub fn subcmd_yaml2txconfig(project_root: &PathBuf, force_online: bool, github_repository: Option<String>, organization_slug: String, project_slug: Option<String>) -> Result<(), CmdY2TCError> {
-    let (transifex_yaml_file, tx_yaml) = try_laod_transifex_yaml_file(project_root)?;
+pub fn subcmd_yaml2txconfig(project_root: &PathBuf, force_online: bool, github_repository: Option<String>, organization_slug: String, project_slug: Option<String>) -> Result<(), CmdError> {
+    let (transifex_yaml_file, tx_yaml) = try_load_transifex_yaml_file(project_root)?;
     println!("Found Transifex project config file at: {transifex_yaml_file:?}");
 
     let github_repository = get_github_repository_from_user_input(project_root, github_repository);

--- a/src/transifex/rest_api.rs
+++ b/src/transifex/rest_api.rs
@@ -8,7 +8,7 @@ use directories::BaseDirs;
 use serde::Deserialize;
 use thiserror::Error as TeError;
 
-use super::{tx_config_file::{load_transifexrc_file, TxConfigLoadError}, yaml_file::TxResourceLookupEntry};
+use super::{tx_config_file::{load_transifexrc_file, LoadTxConfigError}, yaml_file::TxResourceLookupEntry};
 
 pub struct TransifexRestApi {
     rest_hostname: String,
@@ -18,9 +18,9 @@ pub struct TransifexRestApi {
 #[derive(TeError, Debug)]
 pub enum TransifexRestApiError {
     #[error("Error making request: {0}")]
-    UreqError(#[from] ureq::Error),
+    Ureq(#[from] ureq::Error),
     #[error("Error parsing response: {0}")]
-    SerdeError(#[from] serde_json::Error),
+    Serde(#[from] serde_json::Error),
 }
 
 #[derive(Deserialize, Clone, Debug)]
@@ -96,7 +96,7 @@ impl TransifexRestApi {
         }
     }
 
-    pub fn new_from_transifexrc() -> Result<Self, TxConfigLoadError> {
+    pub fn new_from_transifexrc() -> Result<Self, LoadTxConfigError> {
         let xdg_dirs = BaseDirs::new().expect("Not able to get xdg base directories");
         let transifexrc_file = xdg_dirs.home_dir().join(".transifexrc");
         let transifexrc = load_transifexrc_file(&transifexrc_file)?;

--- a/src/transifex/yaml_file.rs
+++ b/src/transifex/yaml_file.rs
@@ -114,7 +114,7 @@ pub struct Settings {
 }
 
 #[derive(TeError, Debug)]
-pub enum TxYamlLoadError {
+pub enum LoadTxYamlError {
     #[error("File not found")]
     FileNotFound,
     #[error("Can not read file")]
@@ -122,10 +122,10 @@ pub enum TxYamlLoadError {
     #[error("Fail to deserialize file: {0}")]
     Serde(#[from] serde_yml::Error),
     #[error("Fail to convert from .tx/config file: {0:?}")]
-    ConvertError(#[from] TxConfigLoadError),
+    ConvertFile(#[from] LoadTxConfigError),
 }
 
-pub fn try_laod_transifex_yaml_file(project_root: &PathBuf) -> Result<(PathBuf, TransifexYaml), TxYamlLoadError> {
+pub fn try_load_transifex_yaml_file(project_root: &PathBuf) -> Result<(PathBuf, TransifexYaml), LoadTxYamlError> {
     // try find transifex.yaml in project_root/transifex.yaml and if not found, try project_root/.tx/transifex.yaml. If still not found, return error.
     let transifex_yaml_file = project_root.join("transifex.yaml");
     if transifex_yaml_file.is_file() {
@@ -138,12 +138,12 @@ pub fn try_laod_transifex_yaml_file(project_root: &PathBuf) -> Result<(PathBuf, 
         return Ok((transifex_yaml_file, tx_yaml));
     }
 
-    Err(TxYamlLoadError::FileNotFound)
+    Err(LoadTxYamlError::FileNotFound)
 }
 
-pub fn load_tx_yaml_file(transifex_yaml_file: &PathBuf) -> Result<TransifexYaml, TxYamlLoadError> {
+pub fn load_tx_yaml_file(transifex_yaml_file: &PathBuf) -> Result<TransifexYaml, LoadTxYamlError> {
     if !transifex_yaml_file.is_file() {
-        return Err(TxYamlLoadError::FileNotFound);
+        return Err(LoadTxYamlError::FileNotFound);
     }
     let source_content = fs::read_to_string(&transifex_yaml_file)?;
     Ok(serde_yml::from_str::<TransifexYaml>(source_content.as_str())?)


### PR DESCRIPTION
- rename the error type in each subcommand module to a simple `CmdError`, as there are no naming conflicts, keeping the name simple.
- rename error type and their field names to "verb + noun" style, instead of "noun + verb" format.
- remove useless `Error` suffix from the members of the error type.

## Summary by Sourcery

Refactor error types and related names across the codebase to follow Rust naming conventions by adopting concise, verb-noun style identifiers and removing redundant “Error” suffixes.

Enhancements:
- Rename error enums for loading configuration and YAML (TxConfigLoadError → LoadTxConfigError, TxYamlLoadError → LoadTxYamlError).
- Adjust error variant names to verb+noun style (e.g. ParseError → ParseFile, LoadPoError → LoadPoFile, UreqError → Ureq).
- Update function signatures and return types across transifex modules, subcommands, REST API, and CLI to use the new error types.
- Merge subcommand-specific error enums (CmdTC2YError, CmdY2TCError) into a single `CmdError` type.